### PR TITLE
Update LINUX.md to reflect current bug in current openssl-client / Remote - SSH interaction

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -464,7 +464,7 @@ You can now change Host to whatever you would like to see as the name of your co
 
 ```bash
 # For instance
-Host "data engineering bootcamp"
+Host data_engineering_bootcamp # Pick a name without spaces, as they currently produce errors. 
   HostName 35.240.107.210
   IdentityFile <file path for your ssh key>
   User <username>


### PR DESCRIPTION
Currently, the suggested ssh config file configuration does not work on Ubuntu 22.04, because it contains spaces. Unless a fix is deployed by the developers of the remote-ssh extension, hostnames with spaces make it unable to connect to the host, because an invalid character error is raised somewhere. See the following [issue on the extension page](
https://github.com/microsoft/vscode-remote-release/issues/9370 )
I had the issue appear for me while trying to connect to my remote VM in the bootcamp yesterday and it took me a good 6 hours to find the fix.
Assuming that it might take Microsoft a while to deploy a fix, I suggest changing the suggested naming for the host to not contain any spaces, so that future Data Engineering Students do not run into the same issue. 