### PR TITLE
Updated spark download link to archive

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -1156,7 +1156,7 @@ cd ~
 Download spark:
 
 ```bash
-wget https://downloads.apache.org/spark/spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz
+wget https://archive.apache.org/dist/spark/spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz
 ```
 
 Open the tarball:

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1123,7 +1123,7 @@ cd ~
 Download spark:
 
 ```bash
-wget https://downloads.apache.org/spark/spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz
+wget https://archive.apache.org/dist/spark/spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz
 ```
 
 Open the tarball:

--- a/_partials/ubuntu_spark.md
+++ b/_partials/ubuntu_spark.md
@@ -12,7 +12,7 @@ cd ~
 Download spark:
 
 ```bash
-wget https://downloads.apache.org/spark/spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz
+wget https://archive.apache.org/dist/spark/spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz
 ```
 
 Open the tarball:

--- a/macOS.md
+++ b/macOS.md
@@ -1121,7 +1121,7 @@ cd ~
 Download spark:
 
 ```bash
-wget https://downloads.apache.org/spark/spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz
+wget https://archive.apache.org/dist/spark/spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz
 ```
 
 Open the tarball:


### PR DESCRIPTION
Title. 

This should prevent the setup breaking whenever Spark has a patch version increase.

FYI @julesvanrie 