### PR TITLE
Post Windows Tests > Updates

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -397,12 +397,12 @@ Terraform is a tool for [Infrastructure as Code (IaC) 🔗](https://en.wikipedia
 
 
 
-Install some basic requirements:
+Install some system requirements requirements:
 ```bash
 sudo apt-get update && sudo apt-get install -y gnupg software-properties-common
 ```
 
-Terraform is not available to **apt** by default, so we need to manually add the repository.
+Terraform is not available on **apt** by default, so we need to manually add the repository.
 ```bash
 wget -O- https://apt.releases.hashicorp.com/gpg | \
     gpg --dearmor | \
@@ -421,7 +421,7 @@ echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
     sudo tee /etc/apt/sources.list.d/hashicorp.list
 ```
 
-Now we can install terraform directly with **apt** 👇
+Now we can install terraform directly with **apt** using:
 ```bash
 sudo apt update
 sudo apt-get install terraform
@@ -439,10 +439,6 @@ The output should look similar to:
 ```bash
 Terraform v1.14.3
 on <your_operating_system>_<your_cpu_architecture>
-
-# Windows example
-# Terraform v1.14.3
-# on windows_amd64
 
 # Linux example
 # Terraform v1.14.3
@@ -523,10 +519,10 @@ instance_user = "<YOUR_COMPUTER_USER_NAME>"
 
 We'll need to change some values in this file. Here's were you can find the required values:
 - **project_id:** from the GCP Console at this [link here](https://console.cloud.google.com).
-- **region:** take a look at the GCP Region and Zone documentation at this [link here](https://cloud.google.com/compute/docs/regions-zones). We strongly recommend you choose the closest geographical region.
-- **zone:** Zone is a subset of region. it is almost always the same as **region** appended with `-a`, `-b`, or `-c`.
+- **region:** take a look at the GCP Region and Zone documentation at this [link here](https://cloud.google.com/compute/docs/regions-zones#available). We generally recommend you choose a geographically nearby region.
+- **zone:** Zone is a subset of region. it is almost always the same as **region** appended with `-a`, `-b`, or `-c`. The zone you select within a region should not have a functional impact.
 - **instance_name:** we recommend naming your VM: `lw-de-vm-<YOUR_GITHUB_USERNAME>`. Replacing `<YOUR_GITHUB_USERNAME>` with your GitHub username.
-- **instance_user:** in your terminal, run `whoami`
+- **instance_user:** in your terminal, run `whoami`, and enter the value
 
 After completing this file, it might look similar to:
 
@@ -624,7 +620,9 @@ A new VS Code window will open. You may be asked to select the platform of the r
 
 ![](/images/vscode_remote_fingerprint.png)
 
-And you are connected! It should look similar too:
+And you are connected 🎉 It should look similar to the below image.
+
+If you don't see a terminal open at the bottom or side of VS Code, you can open a terminal by selecting **Terminal** from the top ribbon menu and selecting **New Terminal** (makes sure to remember the key binding for later 😎)
 
 ![](/images/vscode_remote_connected.png)
 
@@ -834,6 +832,50 @@ Let's enhance the developer experience on your Virtual Machine by install Le Wag
 To customise this configuration for yourself, you'll need to **fork** the repository to your own Github account.
 
 **Forking** creates a copy of the repository under your account (`your_github_username/dotfiles`), which you can then modify with your personal information, such as your name.
+
+<details>
+<summary><strong>❗ I started a Le Wagon _Web Development_ or _Data Science_ bootcamp in 2021 or earlier.</strong></summary>
+
+Open a ticket with a TA and do the following:
+- Compare your existing dotfiles with the current Le Wagon [dotfile 🔗](https://github.com/lewagon/dotfiles), particularly the `.zshrc` and `settings.json` - if there is no meaningful difference, continue with the setup.
+- If you are OK with losing your existing dotfiles - delete your existing dotfiles repository and continue with the setup
+- If you do not want to lose your existing dotfiles, you can either:
+    1. Work with branches
+    2. Create a _psuedo fork_ of the Le Wagon dotfiles repository
+
+**Option 1. I want to work with branches:**
+- Create a branch of your existing dotfiles setup
+- On `main`, pull from `upstream`, resolve conflicts, commit and push. It is important that you accept incoming changes to the `.zshrc` and `settings.json` files
+- Continue with the setup
+
+**Option 2. I want a separate repo for this set of dotfiles:**
+- Cloning the repository to a different target name
+    ```bash
+    mkdir -p ~/dotfiles-wagon && git clone git@github.com:lewagon/dotfiles.git ~/dotfiles-wagon
+    ```
+- Rename the existing `origin` remote to `upstream`
+    ```bash
+    cd ~/dotfiles-wagon && git remote rename origin upstream
+    ```
+- Create a new GitHub repository from directory
+    ```bash
+    cd ~/dotfiles-wagon && gh repo create dotfiles-wagon --source=. --remote=origin
+    ```
+- Verify your remotes:
+    ```bash
+    git remote -v
+
+    # origin  git@github.com:<your_github_username>/dotfiles-wagon.git (fetch)
+    # origin  git@github.com:<your_github_username>/dotfiles-wagon.git (push)
+    # upstream        git@github.com:lewagon/dotfiles.git (fetch)
+    # upstream        git@github.com:lewagon/dotfiles.git (push)
+    ```
+- Delete this current folder
+    ```bash
+    cd ~ && rm -rf ~/dotfiles-wagon
+    ```
+- Continue with the setup - replace occurrences of `dotfiles` in the following commands with `dotfiles-wagon`
+</details>
 
 Open your terminal on your VM and run the following command:
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -352,7 +352,7 @@ To install terraform, download the **zip archive** from the Terraform install pa
 
 4. Navigate to your home directory (`C:\Users\<YOUR_USERNAME>\`) and create a directory named `terraform_cli`
 
-5. Paste `terraform.exe` in the `cli_apps` directory
+5. Paste `terraform.exe` in the `terraform_cli` directory
 
 ### Add terraform to PATH
 
@@ -365,9 +365,9 @@ To update your path:
 
 3. Under **User variables for <YOUR_USERNAME>** click on the variable named: `Path` to select it, then click on **Edit**
 
-3. In the new pop out window, click **New** on to top right
+3. In the new pop out window, click **New** on the top right
 
-4. Enter: `C:\Users\YOUR_USERNAME\terraform_cli` - Make sure to replace `YOUR_USERNAME` with _your user name_. You can obtain your user name by running `echo %username%` in **Command Prompt**
+4. Into the empty box that was just created, enter: `%USERPROFILE%\terraform_cli`
 
 5. Click **Ok** to close the `Path` variable window, and click **Ok** again to close the Environment Variable window.
 
@@ -390,10 +390,6 @@ on <your_operating_system>_<your_cpu_architecture>
 # Windows example
 # Terraform v1.14.3
 # on windows_amd64
-
-# Linux example
-# Terraform v1.14.3
-# on linux_amd64
 ```
 
 
@@ -474,10 +470,10 @@ instance_user = "<YOUR_COMPUTER_USER_NAME>"
 
 We'll need to change some values in this file. Here's were you can find the required values:
 - **project_id:** from the GCP Console at this [link here](https://console.cloud.google.com).
-- **region:** take a look at the GCP Region and Zone documentation at this [link here](https://cloud.google.com/compute/docs/regions-zones). We strongly recommend you choose the closest geographical region.
-- **zone:** Zone is a subset of region. it is almost always the same as **region** appended with `-a`, `-b`, or `-c`.
+- **region:** take a look at the GCP Region and Zone documentation at this [link here](https://cloud.google.com/compute/docs/regions-zones#available). We generally recommend you choose a geographically nearby region.
+- **zone:** Zone is a subset of region. it is almost always the same as **region** appended with `-a`, `-b`, or `-c`. The zone you select within a region should not have a functional impact.
 - **instance_name:** we recommend naming your VM: `lw-de-vm-<YOUR_GITHUB_USERNAME>`. Replacing `<YOUR_GITHUB_USERNAME>` with your GitHub username.
-- **instance_user:** in Command Prompt, run `echo %username%`
+- **instance_user:** in Command Prompt, run `echo %username%`, and enter the value
 
 After completing this file, it might look similar to:
 
@@ -596,7 +592,9 @@ A new VS Code window will open. You may be asked to select the platform of the r
 
 ![](/images/vscode_remote_fingerprint.png)
 
-And you are connected! It should look similar too:
+And you are connected 🎉 It should look similar to the below image.
+
+If you don't see a terminal open at the bottom or side of VS Code, you can open a terminal by selecting **Terminal** from the top ribbon menu and selecting **New Terminal** (makes sure to remember the key binding for later 😎)
 
 ![](/images/vscode_remote_connected.png)
 
@@ -806,6 +804,50 @@ Let's enhance the developer experience on your Virtual Machine by install Le Wag
 To customise this configuration for yourself, you'll need to **fork** the repository to your own Github account.
 
 **Forking** creates a copy of the repository under your account (`your_github_username/dotfiles`), which you can then modify with your personal information, such as your name.
+
+<details>
+<summary><strong>❗ I started a Le Wagon _Web Development_ or _Data Science_ bootcamp in 2021 or earlier.</strong></summary>
+
+Open a ticket with a TA and do the following:
+- Compare your existing dotfiles with the current Le Wagon [dotfile 🔗](https://github.com/lewagon/dotfiles), particularly the `.zshrc` and `settings.json` - if there is no meaningful difference, continue with the setup.
+- If you are OK with losing your existing dotfiles - delete your existing dotfiles repository and continue with the setup
+- If you do not want to lose your existing dotfiles, you can either:
+    1. Work with branches
+    2. Create a _psuedo fork_ of the Le Wagon dotfiles repository
+
+**Option 1. I want to work with branches:**
+- Create a branch of your existing dotfiles setup
+- On `main`, pull from `upstream`, resolve conflicts, commit and push. It is important that you accept incoming changes to the `.zshrc` and `settings.json` files
+- Continue with the setup
+
+**Option 2. I want a separate repo for this set of dotfiles:**
+- Cloning the repository to a different target name
+    ```bash
+    mkdir -p ~/dotfiles-wagon && git clone git@github.com:lewagon/dotfiles.git ~/dotfiles-wagon
+    ```
+- Rename the existing `origin` remote to `upstream`
+    ```bash
+    cd ~/dotfiles-wagon && git remote rename origin upstream
+    ```
+- Create a new GitHub repository from directory
+    ```bash
+    cd ~/dotfiles-wagon && gh repo create dotfiles-wagon --source=. --remote=origin
+    ```
+- Verify your remotes:
+    ```bash
+    git remote -v
+
+    # origin  git@github.com:<your_github_username>/dotfiles-wagon.git (fetch)
+    # origin  git@github.com:<your_github_username>/dotfiles-wagon.git (push)
+    # upstream        git@github.com:lewagon/dotfiles.git (fetch)
+    # upstream        git@github.com:lewagon/dotfiles.git (push)
+    ```
+- Delete this current folder
+    ```bash
+    cd ~ && rm -rf ~/dotfiles-wagon
+    ```
+- Continue with the setup - replace occurrences of `dotfiles` in the following commands with `dotfiles-wagon`
+</details>
 
 Open your terminal on your VM and run the following command:
 

--- a/_partials/dotfiles_simple.md
+++ b/_partials/dotfiles_simple.md
@@ -6,6 +6,50 @@ To customise this configuration for yourself, you'll need to **fork** the reposi
 
 **Forking** creates a copy of the repository under your account (`your_github_username/dotfiles`), which you can then modify with your personal information, such as your name.
 
+<details>
+<summary><strong>❗ I started a Le Wagon _Web Development_ or _Data Science_ bootcamp in 2021 or earlier.</strong></summary>
+
+Open a ticket with a TA and do the following:
+- Compare your existing dotfiles with the current Le Wagon [dotfile 🔗](https://github.com/lewagon/dotfiles), particularly the `.zshrc` and `settings.json` - if there is no meaningful difference, continue with the setup.
+- If you are OK with losing your existing dotfiles - delete your existing dotfiles repository and continue with the setup
+- If you do not want to lose your existing dotfiles, you can either:
+    1. Work with branches
+    2. Create a _psuedo fork_ of the Le Wagon dotfiles repository
+
+**Option 1. I want to work with branches:**
+- Create a branch of your existing dotfiles setup
+- On `main`, pull from `upstream`, resolve conflicts, commit and push. It is important that you accept incoming changes to the `.zshrc` and `settings.json` files
+- Continue with the setup
+
+**Option 2. I want a separate repo for this set of dotfiles:**
+- Cloning the repository to a different target name
+    ```bash
+    mkdir -p ~/dotfiles-wagon && git clone git@github.com:lewagon/dotfiles.git ~/dotfiles-wagon
+    ```
+- Rename the existing `origin` remote to `upstream`
+    ```bash
+    cd ~/dotfiles-wagon && git remote rename origin upstream
+    ```
+- Create a new GitHub repository from directory
+    ```bash
+    cd ~/dotfiles-wagon && gh repo create dotfiles-wagon --source=. --remote=origin
+    ```
+- Verify your remotes:
+    ```bash
+    git remote -v
+
+    # origin  git@github.com:<your_github_username>/dotfiles-wagon.git (fetch)
+    # origin  git@github.com:<your_github_username>/dotfiles-wagon.git (push)
+    # upstream        git@github.com:lewagon/dotfiles.git (fetch)
+    # upstream        git@github.com:lewagon/dotfiles.git (push)
+    ```
+- Delete this current folder
+    ```bash
+    cd ~ && rm -rf ~/dotfiles-wagon
+    ```
+- Continue with the setup - replace occurrences of `dotfiles` in the following commands with `dotfiles-wagon`
+</details>
+
 Open your terminal on your VM and run the following command:
 
 ```bash

--- a/_partials/terraform.md
+++ b/_partials/terraform.md
@@ -29,7 +29,7 @@ To install terraform, download the **zip archive** from the Terraform install pa
 
 4. Navigate to your home directory (`C:\Users\<YOUR_USERNAME>\`) and create a directory named `terraform_cli`
 
-5. Paste `terraform.exe` in the `cli_apps` directory
+5. Paste `terraform.exe` in the `terraform_cli` directory
 
 ### Add terraform to PATH
 
@@ -44,7 +44,7 @@ To update your path:
 
 3. In the new pop out window, click **New** on to top right
 
-4. Enter: `C:\Users\YOUR_USERNAME\terraform_cli` - Make sure to replace `YOUR_USERNAME` with _your user name_. You can obtain your user name by running `echo %username%` in **Command Prompt**
+4. Into the empty box that was just created, enter: `%USERPROFILE%\terraform_cli`
 
 5. Click **Ok** to close the `Path` variable window, and click **Ok** again to close the Environment Variable window.
 
@@ -54,12 +54,12 @@ $WINDOWS_END
 
 $LINUX_START
 
-Install some basic requirements:
+Install some system requirements requirements:
 ```bash
 sudo apt-get update && sudo apt-get install -y gnupg software-properties-common
 ```
 
-Terraform is not available to **apt** by default, so we need to manually add the repository.
+Terraform is not available on **apt** by default, so we need to manually add the repository.
 ```bash
 wget -O- https://apt.releases.hashicorp.com/gpg | \
     gpg --dearmor | \
@@ -78,7 +78,7 @@ echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
     sudo tee /etc/apt/sources.list.d/hashicorp.list
 ```
 
-Now we can install terraform directly with **apt** 👇
+Now we can install terraform directly with **apt** using:
 ```bash
 sudo apt update
 sudo apt-get install terraform
@@ -98,11 +98,19 @@ The output should look similar to:
 Terraform v1.14.3
 on <your_operating_system>_<your_cpu_architecture>
 
+$MAC_START
+# macOS (M chip) example
+# Terraform 1.14.3
+# on darwin_arm64
+$MAC_END
+$WINDOWS_START
 # Windows example
 # Terraform v1.14.3
 # on windows_amd64
-
+$WINDOWS_END
+$LINUX_START
 # Linux example
 # Terraform v1.14.3
 # on linux_amd64
+$LINUX_END
 ```

--- a/_partials/terraform.md
+++ b/_partials/terraform.md
@@ -42,7 +42,7 @@ To update your path:
 
 3. Under **User variables for <YOUR_USERNAME>** click on the variable named: `Path` to select it, then click on **Edit**
 
-3. In the new pop out window, click **New** on to top right
+3. In the new pop out window, click **New** on the top right
 
 4. Into the empty box that was just created, enter: `%USERPROFILE%\terraform_cli`
 

--- a/_partials/terraform_vm.md
+++ b/_partials/terraform_vm.md
@@ -119,17 +119,17 @@ instance_user = "<YOUR_COMPUTER_USER_NAME>"
 
 We'll need to change some values in this file. Here's were you can find the required values:
 - **project_id:** from the GCP Console at this [link here](https://console.cloud.google.com).
-- **region:** take a look at the GCP Region and Zone documentation at this [link here](https://cloud.google.com/compute/docs/regions-zones). We strongly recommend you choose the closest geographical region.
-- **zone:** Zone is a subset of region. it is almost always the same as **region** appended with `-a`, `-b`, or `-c`.
+- **region:** take a look at the GCP Region and Zone documentation at this [link here](https://cloud.google.com/compute/docs/regions-zones#available). We generally recommend you choose a geographically nearby region.
+- **zone:** Zone is a subset of region. it is almost always the same as **region** appended with `-a`, `-b`, or `-c`. The zone you select within a region should not have a functional impact.
 - **instance_name:** we recommend naming your VM: `lw-de-vm-<YOUR_GITHUB_USERNAME>`. Replacing `<YOUR_GITHUB_USERNAME>` with your GitHub username.
 $MAC_START
-- **instance_user:** in your terminal, run `whoami`
+- **instance_user:** in your terminal, run `whoami`, and enter the value
 $MAC_END
 $WINDOWS_START
-- **instance_user:** in Command Prompt, run `echo %username%`
+- **instance_user:** in Command Prompt, run `echo %username%`, and enter the value
 $WINDOWS_END
 $LINUX_START
-- **instance_user:** in your terminal, run `whoami`
+- **instance_user:** in your terminal, run `whoami`, and enter the value
 $LINUX_END
 
 After completing this file, it might look similar to:

--- a/_partials/vscode_ssh_connection.md
+++ b/_partials/vscode_ssh_connection.md
@@ -62,7 +62,9 @@ A new VS Code window will open. You may be asked to select the platform of the r
 
 ![](/images/vscode_remote_fingerprint.png)
 
-And you are connected! It should look similar too:
+And you are connected 🎉 It should look similar to the below image.
+
+If you don't see a terminal open at the bottom or side of VS Code, you can open a terminal by selecting **Terminal** from the top ribbon menu and selecting **New Terminal** (makes sure to remember the key binding for later 😎)
 
 ![](/images/vscode_remote_connected.png)
 

--- a/automation/vm-ansible-setup/playbooks/setup_vm_part1.yml
+++ b/automation/vm-ansible-setup/playbooks/setup_vm_part1.yml
@@ -14,8 +14,16 @@
           - "Running Ubuntu version: {{ ansible_distribution_release }}"
           - "On architecture: {{ architecture }}"
 
-    - name: Install apt packages
+    - name: apt update, upgrade, and install
       block:
+        - name: Update and upgrade apt packages
+          ansible.builtin.apt:
+            update_cache: yes
+            upgrade: dist
+          environment:
+            DEBIAN_FRONTEND: noninteractive
+            NEEDRESTART_MODE: a
+
         - name: Install required apt packages
           apt:
             name:
@@ -57,8 +65,8 @@
               - libpython3-dev
               - openjdk-8-jdk-headless
             state: present
-          become: true
-          tags: apt
+      become: true
+      tags: apt
 
     - name: Set zsh as default shell
       user:

--- a/macOS.md
+++ b/macOS.md
@@ -456,13 +456,9 @@ The output should look similar to:
 Terraform v1.14.3
 on <your_operating_system>_<your_cpu_architecture>
 
-# Windows example
-# Terraform v1.14.3
-# on windows_amd64
-
-# Linux example
-# Terraform v1.14.3
-# on linux_amd64
+# macOS (M chip) example
+# Terraform 1.14.3
+# on darwin_arm64
 ```
 
 
@@ -541,10 +537,10 @@ instance_user = "<YOUR_COMPUTER_USER_NAME>"
 
 We'll need to change some values in this file. Here's were you can find the required values:
 - **project_id:** from the GCP Console at this [link here](https://console.cloud.google.com).
-- **region:** take a look at the GCP Region and Zone documentation at this [link here](https://cloud.google.com/compute/docs/regions-zones). We strongly recommend you choose the closest geographical region.
-- **zone:** Zone is a subset of region. it is almost always the same as **region** appended with `-a`, `-b`, or `-c`.
+- **region:** take a look at the GCP Region and Zone documentation at this [link here](https://cloud.google.com/compute/docs/regions-zones#available). We generally recommend you choose a geographically nearby region.
+- **zone:** Zone is a subset of region. it is almost always the same as **region** appended with `-a`, `-b`, or `-c`. The zone you select within a region should not have a functional impact.
 - **instance_name:** we recommend naming your VM: `lw-de-vm-<YOUR_GITHUB_USERNAME>`. Replacing `<YOUR_GITHUB_USERNAME>` with your GitHub username.
-- **instance_user:** in your terminal, run `whoami`
+- **instance_user:** in your terminal, run `whoami`, and enter the value
 
 After completing this file, it might look similar to:
 
@@ -642,7 +638,9 @@ A new VS Code window will open. You may be asked to select the platform of the r
 
 ![](/images/vscode_remote_fingerprint.png)
 
-And you are connected! It should look similar too:
+And you are connected 🎉 It should look similar to the below image.
+
+If you don't see a terminal open at the bottom or side of VS Code, you can open a terminal by selecting **Terminal** from the top ribbon menu and selecting **New Terminal** (makes sure to remember the key binding for later 😎)
 
 ![](/images/vscode_remote_connected.png)
 
@@ -852,6 +850,50 @@ Let's enhance the developer experience on your Virtual Machine by install Le Wag
 To customise this configuration for yourself, you'll need to **fork** the repository to your own Github account.
 
 **Forking** creates a copy of the repository under your account (`your_github_username/dotfiles`), which you can then modify with your personal information, such as your name.
+
+<details>
+<summary><strong>❗ I started a Le Wagon _Web Development_ or _Data Science_ bootcamp in 2021 or earlier.</strong></summary>
+
+Open a ticket with a TA and do the following:
+- Compare your existing dotfiles with the current Le Wagon [dotfile 🔗](https://github.com/lewagon/dotfiles), particularly the `.zshrc` and `settings.json` - if there is no meaningful difference, continue with the setup.
+- If you are OK with losing your existing dotfiles - delete your existing dotfiles repository and continue with the setup
+- If you do not want to lose your existing dotfiles, you can either:
+    1. Work with branches
+    2. Create a _psuedo fork_ of the Le Wagon dotfiles repository
+
+**Option 1. I want to work with branches:**
+- Create a branch of your existing dotfiles setup
+- On `main`, pull from `upstream`, resolve conflicts, commit and push. It is important that you accept incoming changes to the `.zshrc` and `settings.json` files
+- Continue with the setup
+
+**Option 2. I want a separate repo for this set of dotfiles:**
+- Cloning the repository to a different target name
+    ```bash
+    mkdir -p ~/dotfiles-wagon && git clone git@github.com:lewagon/dotfiles.git ~/dotfiles-wagon
+    ```
+- Rename the existing `origin` remote to `upstream`
+    ```bash
+    cd ~/dotfiles-wagon && git remote rename origin upstream
+    ```
+- Create a new GitHub repository from directory
+    ```bash
+    cd ~/dotfiles-wagon && gh repo create dotfiles-wagon --source=. --remote=origin
+    ```
+- Verify your remotes:
+    ```bash
+    git remote -v
+
+    # origin  git@github.com:<your_github_username>/dotfiles-wagon.git (fetch)
+    # origin  git@github.com:<your_github_username>/dotfiles-wagon.git (push)
+    # upstream        git@github.com:lewagon/dotfiles.git (fetch)
+    # upstream        git@github.com:lewagon/dotfiles.git (push)
+    ```
+- Delete this current folder
+    ```bash
+    cd ~ && rm -rf ~/dotfiles-wagon
+    ```
+- Continue with the setup - replace occurrences of `dotfiles` in the following commands with `dotfiles-wagon`
+</details>
 
 Open your terminal on your VM and run the following command:
 


### PR DESCRIPTION
Minor fixes:
- Local terraform install: Windows - simplified adding directory to `Path`
- Terraform to create VM: updated hyperlinks for region to point at a more relevant section of GCP docs
- SSH Connection: VS Code connection, added fallback if terminal is closed by default
- dotfiles: added section for Alumni that have dotfiles from 2021 or earlier
- Ansible/playbook 1: Added `apt update && apt upgrade`, the time cost is worth it
- Minor typo corrections