### PR TITLE
parametrise ssh key name

### DIFF
--- a/_partials/ssh_key.md
+++ b/_partials/ssh_key.md
@@ -49,8 +49,8 @@ To create a separate SSH key to exclusively use for this bootcamp use the follow
 
 ```bash
 # replace your_email@example.com, this is purely informative and allows you to remember the use of this key
-ssh-keygen -t ed25519 -f ~/.ssh/de-bootcamp -C your_email@example.com
+ssh-keygen -t ed25519 -f ~/.ssh/{{ key_name }} -C your_email@example.com
 ```
 
-Your new SSH Key will be named `de-bootcamp`. Make sure to remember it for later!
+Your new SSH Key will be named `{{ key_name }}`. Make sure to remember it for later!
 </details>

--- a/_partials/vscode_remote_ssh.md
+++ b/_partials/vscode_remote_ssh.md
@@ -66,7 +66,7 @@ You can now change Host to whatever you would like to see as the name of your co
 
 ```bash
 # For instance
-Host "de-bootcamp-vm"
+Host "{{ vm_hostname }}"
   HostName 34.77.50.76 # replace with your VM's public IP address
   IdentityFile <file path for your ssh key>
   User <username>

--- a/builds/LINUX.yml
+++ b/builds/LINUX.yml
@@ -6,11 +6,15 @@ partials:
   - setup/ubuntu_slack
   - setup/slack_settings
   - setup/github
-  - ssh_key
+  - name: ssh_key
+    vars:
+      key_name: de-bootcamp
   - gcp_setup
   - virtual_machine
   - setup/ubuntu_vscode
-  - vscode_remote_ssh
+  - name: vscode_remote_ssh
+    vars:
+      vm_hostname: de-bootcamp-vm
   - vscode_extensions
   - cli_tools
   - setup/oh_my_zsh

--- a/builds/WINDOWS.yml
+++ b/builds/WINDOWS.yml
@@ -6,11 +6,15 @@ partials:
   - setup/windows_slack
   - setup/slack_settings
   - setup/github
-  - ssh_key
+  - name: ssh_key
+    vars:
+      key_name: de-bootcamp
   - gcp_setup
   - virtual_machine
   - win_vscode
-  - vscode_remote_ssh
+  - name: vscode_remote_ssh
+    vars:
+      vm_hostname: de-bootcamp-vm
   - vscode_extensions
   - cli_tools
   - setup/oh_my_zsh

--- a/builds/macOS.yml
+++ b/builds/macOS.yml
@@ -6,11 +6,15 @@ partials:
   - setup/macos_slack
   - setup/slack_settings
   - setup/github
-  - ssh_key
+  - name: ssh_key
+    vars:
+      key_name: de-bootcamp
   - gcp_setup
   - virtual_machine
   - osx_vscode
-  - vscode_remote_ssh
+  - name: vscode_remote_ssh
+    vars:
+      vm_hostname: de-bootcamp-vm
   - vscode_extensions
   - cli_tools
   - setup/oh_my_zsh


### PR DESCRIPTION

allows the `lewagon/data-setup` data setup to change the ssh key name

showcases the syntax for params, even though the value could be better off in `constants/constants.yml`
