### PR TITLE
Align gcloud install with official instructions

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -329,11 +329,10 @@ The `gcloud` Command Line Interface (CLI) is used to communicate with Google Clo
 Add the `APT` repository and install with:
 
 ```bash
+sudo apt-get update && sudo apt-get install ca-certificates gnupg curl
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-sudo apt-get install apt-transport-https ca-certificates gnupg
-curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-sudo apt-get update && sudo apt-get install google-cloud-sdk
-sudo apt-get install google-cloud-sdk-app-engine-python
+sudo apt-get update && sudo apt-get install google-cloud-cli
 ```
 
 To test your install, open a new terminal and run:

--- a/_partials/es/ubuntu_gcloud.md
+++ b/_partials/es/ubuntu_gcloud.md
@@ -2,10 +2,9 @@
 
 Instala la CLI de `gcloud` para comunicar con [Google Cloud Platform](https://cloud.google.com/) a través de la terminal:
 ```bash
+sudo apt-get update && sudo apt-get install ca-certificates gnupg curl
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-sudo apt-get install apt-transport-https ca-certificates gnupg
-curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-sudo apt-get update && sudo apt-get install google-cloud-sdk
-sudo apt-get install google-cloud-sdk-app-engine-python
+sudo apt-get update && sudo apt-get install google-cloud-cli
 ```
 👉 [Documentación para la instalación](https://cloud.google.com/sdk/docs/install#deb)

--- a/_partials/gcp_cli_setup.md
+++ b/_partials/gcp_cli_setup.md
@@ -119,11 +119,10 @@ Now `gcloud` is installed and authenticated 🚀
 Add the `APT` repository and install with:
 
 ```bash
+sudo apt-get update && sudo apt-get install ca-certificates gnupg curl
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-sudo apt-get install apt-transport-https ca-certificates gnupg
-curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-sudo apt-get update && sudo apt-get install google-cloud-sdk
-sudo apt-get install google-cloud-sdk-app-engine-python
+sudo apt-get update && sudo apt-get install google-cloud-cli
 ```
 
 To test your install, open a new terminal and run:

--- a/_partials/ubuntu_gcloud.md
+++ b/_partials/ubuntu_gcloud.md
@@ -2,11 +2,10 @@
 
 Install the `gcloud` CLI to communicate with [Google Cloud Platform](https://cloud.google.com/) through your terminal:
 ```bash
+sudo apt-get update && sudo apt-get install ca-certificates gnupg curl
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-sudo apt-get install apt-transport-https ca-certificates gnupg
-curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-sudo apt-get update && sudo apt-get install google-cloud-sdk
-sudo apt-get install google-cloud-sdk-app-engine-python
+sudo apt-get update && sudo apt-get install google-cloud-cli
 ```
 👉 [Install documentation](https://cloud.google.com/sdk/docs/install#deb)
 


### PR DESCRIPTION
Removes the deprecated use of apt-key.

Aligns with changes made on main in lewagon/data-engineering-setup#94