### PR TITLE
Use $HOME i.o. tilde for Windows 10

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -513,7 +513,7 @@ Type `exit` to get back to your local machine.
 Still on your *local* computer, lets create a more readable version of your machine to connect to!
 
 ```bash
-code ~/.ssh/config
+code $HOME/.ssh/config
 ```
 
 You should see something like the following:

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -481,7 +481,7 @@ Type `exit` to get back to your local machine.
 Still on your *local* computer, lets create a more readable version of your machine to connect to!
 
 ```bash
-code ~/.ssh/config
+code $HOME/.ssh/config
 ```
 
 You should see something like the following:

--- a/_partials/vscode_ssh_connection.md
+++ b/_partials/vscode_ssh_connection.md
@@ -84,7 +84,7 @@ If that didn't help:
 Still on your *local* computer, lets create a more readable version of your machine to connect to!
 
 ```bash
-code ~/.ssh/config
+code $HOME/.ssh/config
 ```
 
 You should see something like the following:

--- a/macOS.md
+++ b/macOS.md
@@ -563,7 +563,7 @@ If that didn't help:
 Still on your *local* computer, lets create a more readable version of your machine to connect to!
 
 ```bash
-code ~/.ssh/config
+code $HOME/.ssh/config
 ```
 
 You should see something like the following:


### PR DESCRIPTION
Previous commit was straight on the Windows guide. And hence was overwritten when the guides were generated from partials.